### PR TITLE
support windows with msys2 (python 3.9.13)

### DIFF
--- a/application/file.py
+++ b/application/file.py
@@ -4,7 +4,8 @@ AACircuit.py
 """
 
 from pubsub import pub
-from locale import gettext as _
+#from locale import gettext as _
+from gettext import gettext as _
 
 import gi
 gi.require_version('Gtk', '3.0')

--- a/application/file.py
+++ b/application/file.py
@@ -4,7 +4,6 @@ AACircuit.py
 """
 
 from pubsub import pub
-#from locale import gettext as _
 from gettext import gettext as _
 
 import gi

--- a/application/grid.py
+++ b/application/grid.py
@@ -7,7 +7,8 @@ AACircuit
 
 import xerox
 
-from locale import gettext as _
+#from locale import gettext as _
+import gettext
 from application import CELL_DEFAULT, CELL_EMPTY, CELL_NEW, CELL_ERASE
 
 
@@ -46,6 +47,7 @@ class Grid(object):
     # clipboard
 
     def content_as_str(self):
+        _ = gettext.gettext
         content = ""
         for r in self._grid:
             line = ""

--- a/application/grid.py
+++ b/application/grid.py
@@ -7,8 +7,7 @@ AACircuit
 
 import xerox
 
-#from locale import gettext as _
-import gettext
+from gettext import gettext as _
 from application import CELL_DEFAULT, CELL_EMPTY, CELL_NEW, CELL_ERASE
 
 
@@ -47,7 +46,6 @@ class Grid(object):
     # clipboard
 
     def content_as_str(self):
-        _ = gettext.gettext
         content = ""
         for r in self._grid:
             line = ""

--- a/application/grid_view.py
+++ b/application/grid_view.py
@@ -7,7 +7,6 @@ import cairo
 import time
 from pubsub import pub
 
-#from locale import gettext as _
 import gettext as _
 from application import HORIZONTAL, VERTICAL
 from application import IDLE, SELECTING, SELECTED

--- a/application/grid_view.py
+++ b/application/grid_view.py
@@ -7,7 +7,8 @@ import cairo
 import time
 from pubsub import pub
 
-from locale import gettext as _
+#from locale import gettext as _
+import gettext as _
 from application import HORIZONTAL, VERTICAL
 from application import IDLE, SELECTING, SELECTED
 from application import CHARACTER, COMPONENT, LINE, MAG_LINE, DIR_LINE, OBJECT, OBJECTS, COL, ROW, RECT, DRAW_RECT, ERASER, ARROW

--- a/application/grid_view.py
+++ b/application/grid_view.py
@@ -7,7 +7,7 @@ import cairo
 import time
 from pubsub import pub
 
-import gettext as _
+from gettext import gettext as _
 from application import HORIZONTAL, VERTICAL
 from application import IDLE, SELECTING, SELECTED
 from application import CHARACTER, COMPONENT, LINE, MAG_LINE, DIR_LINE, OBJECT, OBJECTS, COL, ROW, RECT, DRAW_RECT, ERASER, ARROW

--- a/application/main_window.py
+++ b/application/main_window.py
@@ -9,7 +9,7 @@ from pubsub import pub
 from threading import Timer
 
 import locale
-from application import gettext as _
+import gettext
 
 from application import get_path_to_data
 from application import ERROR, INFO
@@ -43,8 +43,10 @@ class MainWindow(Gtk.Window):
             # For this particular case the locale module needs to be used instead of gettext.
             # Python's gettext module is pure python, it doesn't actually set the text domain
             # in a way that the C library can read, but locale does (by calling libc).
-            locale.bindtextdomain('aacircuit', get_path_to_data('locale/'))
-            locale.textdomain('aacircuit')
+ #           locale.bindtextdomain('aacircuit', get_path_to_data('locale/'))
+ #           locale.textdomain('aacircuit')
+            gettext.bindtextdomain('aacircuit', get_path_to_data('locale/'))
+            gettext.textdomain('aacircuit')
 
             builder = Gtk.Builder()
             # https://stackoverflow.com/questions/24320502/how-to-translate-pygtk-glade-gtk-builder-application
@@ -280,6 +282,7 @@ class MainWindow(Gtk.Window):
         return not self.on_close_clicked()
 
     def on_close_clicked(self, item=None):
+        _ = gettext.gettext
         if self._undo_stack_empty or self.show_confirmation_dlg():
             print(_("Closing application"))
             Gtk.main_quit()

--- a/application/main_window.py
+++ b/application/main_window.py
@@ -9,7 +9,7 @@ from pubsub import pub
 from threading import Timer
 
 import locale
-import gettext
+from gettext import gettext as _
 
 from application import get_path_to_data
 from application import ERROR, INFO
@@ -39,12 +39,6 @@ class MainWindow(Gtk.Window):
         https://eeperry.wordpress.com/2013/01/05/pygtk-new-style-python-class-using-builder/
         """
         try:
-            # https://askubuntu.com/questions/140552/how-to-make-glade-load-translations-from-opt
-            # For this particular case the locale module needs to be used instead of gettext.
-            # Python's gettext module is pure python, it doesn't actually set the text domain
-            # in a way that the C library can read, but locale does (by calling libc).
- #           locale.bindtextdomain('aacircuit', get_path_to_data('locale/'))
- #           locale.textdomain('aacircuit')
             gettext.bindtextdomain('aacircuit', get_path_to_data('locale/'))
             gettext.textdomain('aacircuit')
 
@@ -282,7 +276,6 @@ class MainWindow(Gtk.Window):
         return not self.on_close_clicked()
 
     def on_close_clicked(self, item=None):
-        _ = gettext.gettext
         if self._undo_stack_empty or self.show_confirmation_dlg():
             print(_("Closing application"))
             Gtk.main_quit()


### PR DESCRIPTION
support windows with msys2 (python 3.9.13)
seems to still work on ubuntu (python 3.10.4)

I have very little python experience. So I'm not sure if these fixes are destroying language localization support or not.
However seems to follow approach used here:
https://stackoverflow.com/questions/10094335/how-to-bind-a-text-domain-to-a-local-folder-for-gettext-under-gtk3